### PR TITLE
BSAPP-490: Wettkampfklasse: Weiterleitung anpassen

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-detail/wettkampfklasse-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-detail/wettkampfklasse-detail.component.ts
@@ -87,11 +87,12 @@ export class WettkampfklasseDetailComponent extends CommonComponent implements O
                 .subscribe((myNotification) => {
                   if (myNotification.userAction === NotificationUserAction.ACCEPTED) {
                     this.saveLoading = false;
-                    this.router.navigateByUrl('/verwaltung/klassen/' + response.payload.id);
+                    this.router.navigateByUrl('/verwaltung/klassen');
                   }
                 });
 
             this.notificationService.showNotification(notification);
+
           }
         }, (response: BogenligaResponse<WettkampfKlasseDO>) => {
           console.log('Failed');


### PR DESCRIPTION
Fixed the bug, where forwarding to the overview of 'Wettkampklassen' after the successful creation of a new 'Wettkampfklasse' was not working.