### PR TITLE
 mki4 Bug_555 and mki4 Bug_551 fixed final

### DIFF
--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.config.ts
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.config.ts
@@ -9,7 +9,7 @@ export const WETTKAEMPFE_CONFIG: NavigationDialogConfig = {
   }
 };
 
-
+// the Ligatabelle is not sortable
 export const LIGATABELLE_TABLE_CONFIG: TableConfig = {
 
   columns: [
@@ -17,26 +17,31 @@ export const LIGATABELLE_TABLE_CONFIG: TableConfig = {
       translationKey: 'WETTKAEMPFE.LIGATABELLE.TABELLENPLATZ',
       propertyName:   'tabellenplatz',
       width:          15,
+      sortable:        false,
     },
     {
       translationKey: 'WETTKAEMPFE.LIGATABELLE.MANNSCHAFTNAME',
       propertyName:   'mannschaft_name',
       width:          70,
+      sortable:        false,
     },
     {
       translationKey: 'WETTKAEMPFE.LIGATABELLE.MATCHPUNKTE',
       propertyName:   'matchpunkte',
       width:          15,
+      sortable:        false,
     },
     {
       translationKey: 'WETTKAEMPFE.LIGATABELLE.SATZPUNKTE',
       propertyName:   'satzpunkte',
       width:          15,
+      sortable:        false,
     },
     {
       translationKey: 'WETTKAEMPFE.LIGATABELLE.SATZPUNKTDIFFERENZ',
       propertyName:   'satzpkt_differenz',
       width:          15,
+      sortable:        false,
     }
   ]
 

--- a/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
@@ -60,10 +60,12 @@ export abstract class BaseTableSorter {
       console.warn('No table configuration found. Abort sorting column: ', sortColumn.propertyName);
       return rows;
     }
+
     // the columns are not sortable --> return rows without sorting
-    if(!this.config.columns[this.config.columns.length - 1].sortable && !this.config.columns[0].sortable){
+    if (this.config.columns.filter((c) => c.sortable).length === 0) {
       return rows;
     }
+
     this.toggleSortOrder(sortColumn);
 
     // the custom sorter overrides the sorterImplementation method

--- a/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
@@ -60,7 +60,10 @@ export abstract class BaseTableSorter {
       console.warn('No table configuration found. Abort sorting column: ', sortColumn.propertyName);
       return rows;
     }
-
+    // the columns are not sortable --> return rows without sorting
+    if(!this.config.columns[this.config.columns.length - 1].sortable && !this.config.columns[0].sortable){
+      return rows;
+    }
     this.toggleSortOrder(sortColumn);
 
     // the custom sorter overrides the sorterImplementation method


### PR DESCRIPTION
Bug 555(Patrik Keppeler) fixed and Bug 551(Mohammed Kalash) fixed. In der Klasse ligatabelle.config die Eigenschaft einer Spalte "sotable" auf false gesetzt, damit die Icons nicht mehr sichtbar sind. Und in der Klasse base-table-sorter.class überprüfen wir vor dem Sortieren ob die erste und letzte Spalte sortierbar (wenn beide nicht sortierbar sind, dann sind ja alle Spalten nicht sortierbar) sind, wenn nein, dann geben wir die zeilen einfach zurück ohne zu sortieren. 