### PR TITLE
+ Änderung im Code: BSAPP-550; zusätzliche Abfrage, ob die Felder für…

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -149,12 +149,12 @@ export class SchusszettelComponent implements OnInit {
         type:        NotificationType.OK,
         userAction:  NotificationUserAction.ACCEPTED
       });
-    } else if(this.match1.schuetzen[0][0].schuetzeNr == null || this.match1.schuetzen[1][0].schuetzeNr == null || this.match1.schuetzen[2][0].schuetzeNr == null
+    } else if (this.match1.schuetzen[0][0].schuetzeNr == null || this.match1.schuetzen[1][0].schuetzeNr == null || this.match1.schuetzen[2][0].schuetzeNr == null
     || this.match2.schuetzen[0][0].schuetzeNr == null || this.match2.schuetzen[1][0].schuetzeNr == null || this.match2.schuetzen[2][0].schuetzeNr == null) {
       this.notificationService.showNotification({
         id:          'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
         title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.TITLE',
-        description: 'Bitte unter Schuetze in alle Felder eine Schuetzennummer eintragen!', //hier ist die Meldung direkt eingefügt
+        description: 'Bitte unter Schuetze in alle Felder eine Schuetzennummer eintragen!', // hier ist die Meldung direkt eingefügt
         severity:    NotificationSeverity.ERROR,
         origin:      NotificationOrigin.SYSTEM,
         type:        NotificationType.OK,

--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -21,6 +21,7 @@ const NOTIFICATION_WEITER_SCHALTEN = 'schusszettel_weiter';
 const NOTIFICATION_SCHUSSZETTEL_EINGABEFEHLER = 'schusszettelEingabefehler';
 const NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN = 'schusszettelEntschieden';
 const NOTIFICATION_SCHUSSZETTEL_SPEICHERN = 'schusszettelSave';
+const NOTIFICATION_SCHUSSZETTEL_SCHUETZENNUMMER = 'schusszettelEntschieden';
 
 
 @Component({
@@ -150,11 +151,11 @@ export class SchusszettelComponent implements OnInit {
         userAction:  NotificationUserAction.ACCEPTED
       });
     } else if (this.match1.schuetzen[0][0].schuetzeNr == null || this.match1.schuetzen[1][0].schuetzeNr == null || this.match1.schuetzen[2][0].schuetzeNr == null
-    || this.match2.schuetzen[0][0].schuetzeNr == null || this.match2.schuetzen[1][0].schuetzeNr == null || this.match2.schuetzen[2][0].schuetzeNr == null) {
+      || this.match2.schuetzen[0][0].schuetzeNr == null || this.match2.schuetzen[1][0].schuetzeNr == null || this.match2.schuetzen[2][0].schuetzeNr == null) {
       this.notificationService.showNotification({
-        id:          'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
-        title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.TITLE',
-        description: 'Bitte unter Schuetze in alle Felder eine Schuetzennummer eintragen!', // hier ist die Meldung direkt eingefügt
+        id:          'NOTIFICATION_SCHUSSZETTEL_SCHUETZENNUMMER',
+        title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.SCHUETZENNUMMER.TITLE',
+        description: 'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.SCHUETZENNUMMER.DESCRIPTION',
         severity:    NotificationSeverity.ERROR,
         origin:      NotificationOrigin.SYSTEM,
         type:        NotificationType.OK,

--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -141,13 +141,24 @@ export class SchusszettelComponent implements OnInit {
   save() {
     if (this.match1.satzpunkte > 7 || this.match2.satzpunkte > 7) {
       this.notificationService.showNotification({
-        id: 'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
-        title: 'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.TITLE',
+        id:          'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
+        title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.TITLE',
         description: 'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.DESCRIPTION',
-        severity: NotificationSeverity.ERROR,
-        origin: NotificationOrigin.SYSTEM,
-        type: NotificationType.OK,
-        userAction: NotificationUserAction.ACCEPTED
+        severity:    NotificationSeverity.ERROR,
+        origin:      NotificationOrigin.SYSTEM,
+        type:        NotificationType.OK,
+        userAction:  NotificationUserAction.ACCEPTED
+      });
+    } else if(this.match1.schuetzen[0][0].schuetzeNr == null || this.match1.schuetzen[1][0].schuetzeNr == null || this.match1.schuetzen[2][0].schuetzeNr == null
+    || this.match2.schuetzen[0][0].schuetzeNr == null || this.match2.schuetzen[1][0].schuetzeNr == null || this.match2.schuetzen[2][0].schuetzeNr == null) {
+      this.notificationService.showNotification({
+        id:          'NOTIFICATION_SCHUSSZETTEL_ENTSCHIEDEN',
+        title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.ENTSCHIEDEN.TITLE',
+        description: 'Bitte unter Schuetze in alle Felder eine Schuetzennummer eintragen!', //hier ist die Meldung direkt eingefügt
+        severity:    NotificationSeverity.ERROR,
+        origin:      NotificationOrigin.SYSTEM,
+        type:        NotificationType.OK,
+        userAction:  NotificationUserAction.ACCEPTED
       });
     } else {
       this.notificationService.showNotification({

--- a/bogenliga/src/assets/i18n/de.json
+++ b/bogenliga/src/assets/i18n/de.json
@@ -121,6 +121,10 @@
           "TITLE":"Eingabefehler - Speichern abgebrochen",
           "DESCRIPTION": "Satzpunkte >7"
         },
+        "SCHUETZENNUMMER":{
+          "TITLE":"Eingabefehler - Speichern abgebrochen",
+          "DESCRIPTION": "Bitte geben sie unter Schuetze alle Schuetzennummern ein ..."
+        },
         "SPEICHERN":{
           "TITLE":"Schusszettel speichern",
           "DESCRIPTION": "Schusszettel wird gespeichert..."


### PR DESCRIPTION
… die Schuetzennummern ausgefüllt sind;
[https://www.exxcellent.de/jira/browse/BSAPP-550](url)
Ursprünglich war das Problem, dass bereits gespeicherte Schusszettel nachträglich bearbeitet werden sollen. Beim erstmaligen Speichern wurden bereits einige Schusszettel korrupt gespeichert und ließen sich nachträglich nicht mehr bearbeiten. Wenn ein Schusszettel gespeichert wurde ohne gültige eingebene Schuetzennummern ließ er sich beim nachträglichen Öffnen zwar anzeigen, enthielt aber korrupte Elemente, fehlende, bzw. duplizierte Einträge in Listen. Dies führte dazu, das die Schusszettel nicht mehr bearbeitet werden konnten. Durch diese Änderung wird vermieden das korrupte Schusszettel überhaupt gespeichert werden und erlaubt es die Schusszettel zu öffnen und nachträglich zu bearbeiten.