### PR TITLE
BSAPP-612

### DIFF
--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
@@ -8,7 +8,7 @@
 
   <bla-col-layout>
 
-    <div #chart></div>
+    <div #chart style="max-width: 100%"></div>
 
     <div id="detailsWrapper" style="display: none;">
       <div id="details">

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
@@ -71,7 +71,7 @@ export class RegionenComponent implements OnInit {
     if (currentRegion == null) {
       color = 'grey';
     } else if (currentRegion.regionTyp === 'BUNDESVERBAND') {
-      color = 'yellow';
+      color = 'orange';
     } else if (currentRegion.regionTyp === 'LANDESVERBAND') {
       color = 'red';
     } else if (currentRegion.regionTyp === 'BEZIRK') {
@@ -103,23 +103,17 @@ export class RegionenComponent implements OnInit {
 
     myChart
       .data(JSON.parse(data))
-      .width(window.innerWidth * chartMaxSizeMultiplikator)
-      .height(window.innerHeight * chartMaxSizeMultiplikator)
+      .width(window.innerWidth * chartDetailsSizeMultiplikator)
+      .height(window.innerHeight * chartDetailsSizeMultiplikator)
       .size('size')
       .color('color')
       .onNodeClick((node) => {
-        if (document.querySelector('.sunburst-tooltip') != null) {
-          document.querySelector('.sunburst-tooltip').remove(); }
         // what should happen after clicking the node
         myChart.focusOnNode(node);
 
-        if (node == null) {
-          myChart.width(window.innerWidth * chartMaxSizeMultiplikator);
-          myChart.height(window.innerHeight * chartMaxSizeMultiplikator);
-        } else {
           myChart.width(window.innerWidth * chartDetailsSizeMultiplikator);
           myChart.height(window.innerHeight * chartDetailsSizeMultiplikator);
-        }
+        //}
         this.showDetails(node);
 
         })
@@ -136,8 +130,8 @@ export class RegionenComponent implements OnInit {
           .height(window.innerHeight * chartDetailsSizeMultiplikator);
       } else {
         myChart
-          .width(window.innerWidth * chartMaxSizeMultiplikator)
-          .height(window.innerHeight * chartMaxSizeMultiplikator);
+          .width(window.innerWidth * chartDetailsSizeMultiplikator)
+          .height(window.innerHeight * chartDetailsSizeMultiplikator);
       }
     });
   }

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
@@ -111,9 +111,9 @@ export class RegionenComponent implements OnInit {
         // what should happen after clicking the node
         myChart.focusOnNode(node);
 
-          myChart.width(window.innerWidth * chartDetailsSizeMultiplikator);
-          myChart.height(window.innerHeight * chartDetailsSizeMultiplikator);
-        //}
+        myChart.width(window.innerWidth * chartDetailsSizeMultiplikator);
+        myChart.height(window.innerHeight * chartDetailsSizeMultiplikator);
+        // }
         this.showDetails(node);
 
         })


### PR DESCRIPTION
Tooltip zum Anzeigen der Kategorien im Sunburst-Chart wieder hinzugefügt. Gleichbleibende größe des Charts neben der Detail-Übersicht. 