### PR TITLE
BSAPP-552

### DIFF
--- a/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
@@ -164,6 +164,40 @@ export abstract class BaseTableSorter {
       return 0;
     };
   }
+  /**
+   * Sort function if you want to sort a array by null values first.
+   *
+   * @see sortTwoFunctions
+   *
+   * @param currentlySortedColumn
+   * @param overrideSortOrder is used, if the sort order of a previous sort function should adopted.
+   * Override sort order, if this function is the second one of the sortTwoFunctions method
+   * @returns {(rowA:any, rowB:any)=>(number|number|number)} sort function.
+   */
+  sortByNull(currentlySortedColumn: TableColumnConfig, overrideSortOrder?: TableColumnSortOrder) {
+    // Get the SortOrder from table-column-type.enum.ts
+    // Is used to make sure you can toggle the collumn.
+    let turnAroundSortOrder = this.setUpSortOrder(currentlySortedColumn.currentSortOrder);
+
+    if (overrideSortOrder) {
+      turnAroundSortOrder = this.setUpSortOrder(overrideSortOrder);
+    }
+
+    return function nullSort(rowA, rowB) {
+
+      let payloadA = rowA.getText(currentlySortedColumn);
+      let payloadB = rowB.getText(currentlySortedColumn);
+      // Swappes input of an array if the payload rowA or row is null and the other not.
+      // attention: null or undefined is changed to '' in .getText(currentlySortedColumn)
+      if (payloadA === '' && payloadB !== '') {
+        return -1 * turnAroundSortOrder;
+      } else if(payloadB === '' && payloadA !== '') {
+        return turnAroundSortOrder;
+      }
+
+      return 0;
+    };
+  }
 
   /**
    * Sort date objects

--- a/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
@@ -168,6 +168,7 @@ export abstract class BaseTableSorter {
    * Sort function if you want to sort a array by null values first.
    *
    * @see sortTwoFunctions
+   * @see sorterImplementation in default-table-sorter.class.ts
    *
    * @param currentlySortedColumn
    * @param overrideSortOrder is used, if the sort order of a previous sort function should adopted.
@@ -187,15 +188,15 @@ export abstract class BaseTableSorter {
 
       const payloadA = rowA.getText(currentlySortedColumn);
       const payloadB = rowB.getText(currentlySortedColumn);
-      // Swappes input of an array if the payload rowA or row is null and the other not.
+      // Swappes inputs of an array if the payload rowA or row is null and the other not.
       // attention: null or undefined is changed to '' in .getText(currentlySortedColumn)
-      if (payloadA === '' && payloadB !== '') {
-        return -1 * turnAroundSortOrder;
-      } else if (payloadB === '' && payloadA !== '') {
+      if (payloadA !== '' && payloadB !== '' || payloadA === '' && payloadB === '') {
+        return 0;
+      } else if (payloadA === '') {
+        return - 1 * turnAroundSortOrder;
+      } else {
         return turnAroundSortOrder;
       }
-
-      return 0;
     };
   }
 

--- a/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/base-table-sorter.class.ts
@@ -185,13 +185,13 @@ export abstract class BaseTableSorter {
 
     return function nullSort(rowA, rowB) {
 
-      let payloadA = rowA.getText(currentlySortedColumn);
-      let payloadB = rowB.getText(currentlySortedColumn);
+      const payloadA = rowA.getText(currentlySortedColumn);
+      const payloadB = rowB.getText(currentlySortedColumn);
       // Swappes input of an array if the payload rowA or row is null and the other not.
       // attention: null or undefined is changed to '' in .getText(currentlySortedColumn)
       if (payloadA === '' && payloadB !== '') {
         return -1 * turnAroundSortOrder;
-      } else if(payloadB === '' && payloadA !== '') {
+      } else if (payloadB === '' && payloadA !== '') {
         return turnAroundSortOrder;
       }
 

--- a/bogenliga/src/app/modules/shared/components/tables/control/default-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/default-table-sorter.class.ts
@@ -16,6 +16,10 @@ export class DefaultTableSorter extends BaseTableSorter {
           return this.sortNumber(currentlySortedColumn);
         case TableColumnType.DATE:
           return this.sortOnDate(currentlySortedColumn);
+        // If its possible that null values appear in a collumn, use this if you want to make sure that null is
+        // smaller than numbers if you use a sort algorithm.
+        case TableColumnType.NULLorNUMBER:
+          return this.sortByNull(currentlySortedColumn);
         case TableColumnType.TRANSLATION_KEY:
           return this.sortTwoFunctions(
             // attention: the translation keys are sorted, not the visible (translated) text

--- a/bogenliga/src/app/modules/shared/components/tables/control/default-table-sorter.class.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/control/default-table-sorter.class.ts
@@ -18,7 +18,7 @@ export class DefaultTableSorter extends BaseTableSorter {
           return this.sortOnDate(currentlySortedColumn);
         // If its possible that null values appear in a collumn, use this if you want to make sure that null is
         // smaller than numbers if you use a sort algorithm.
-        case TableColumnType.NULLorNUMBER:
+        case TableColumnType.NULLORNUMBER:
           return this.sortByNull(currentlySortedColumn);
         case TableColumnType.TRANSLATION_KEY:
           return this.sortTwoFunctions(

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
@@ -4,5 +4,5 @@ export enum TableColumnType {
   DATE,
   TRANSLATION_KEY, // i18n key
   CUSTOM_MAPPING, // use a function to manipulate the cell value
-  NULLorNUMBER=5 // used in sportjahresplan.config.ts to make sure null values are sorted before numbers
+  NULLorNUMBER= 5 // used in sportjahresplan.config.ts to make sure null values are sorted before numbers
 }

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
@@ -4,5 +4,5 @@ export enum TableColumnType {
   DATE,
   TRANSLATION_KEY, // i18n key
   CUSTOM_MAPPING, // use a function to manipulate the cell value
-  NULLorNUMBER= 5 // used in sportjahresplan.config.ts to make sure null values are sorted before numbers
+  NULLORNUMBER= 5 // used in sportjahresplan.config.ts to make sure null values are sorted before numbers
 }

--- a/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/types/table-column-type.enum.ts
@@ -3,5 +3,6 @@ export enum TableColumnType {
   NUMBER,
   DATE,
   TRANSLATION_KEY, // i18n key
-  CUSTOM_MAPPING // use a function to manipulate the cell value
+  CUSTOM_MAPPING, // use a function to manipulate the cell value
+  NULLorNUMBER=5 // used in sportjahresplan.config.ts to make sure null values are sorted before numbers
 }

--- a/bogenliga/src/app/modules/sportjahresplan/components/sportjahresplan/sportjahresplan.config.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/sportjahresplan/sportjahresplan.config.ts
@@ -67,12 +67,14 @@ export const MATCH_TABLE_CONFIG: TableConfig = {
     {
       translationKey: 'SPORTJAHRESPLAN.MATCH.TABLE.BEGEGNUNG',
       propertyName:   'begegnung',
-      width:          5,
+      width:          5
     },
     {
       translationKey: 'SPORTJAHRESPLAN.MATCH.TABLE.MATCHPUNKTE',
       propertyName:   'matchpunkte',
-      width:          5,
+      type:            5,
+      currentSortOrder: 1,
+      width:           5
     },
     {
       translationKey: 'SPORTJAHRESPLAN.MATCH.TABLE.SATZPUNKTE',


### PR DESCRIPTION
Ich hab eine neue Sortier variante hinzugefügt um null Werte vor Number Werte zu sortieren und damit die gewünschte Reihenfolge in der Ligatabelle Durchzuführung zu erreichen.
Über das Enum NULLORNUMBER in  table-column-type.enum.ts  kann nun bestimmt werden, dass in dieser column nach null Werten sortiert werden soll.