### PR TITLE
Anpassen der inneren for Schleife für das Hinzufügen von passen

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/mapper/match-mapper-ext.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/mapper/match-mapper-ext.ts
@@ -40,16 +40,18 @@ export class MatchMapperExt {
         }
 
       }
-      for (let i = 0; i < 3; i++) {
-        for (let j = 0; j < 5 - schuetzen[i].length; j++) {
-          schuetzen[i].push(new PasseDO(null, payload.id, payload.mannschaftId, payload.wettkampfId, payload.nr, j + 1));
-        }
-      }
+
       for (let i = 0; i < schuetzen[0].length; i++) {
         for (const passen of schuetzen) {
           if (i < passen.length) {
             sumSatz[i] += passen[i].ringzahlPfeil1 + passen[i].ringzahlPfeil2;
           }
+        }
+      }
+      for (let i = 0; i < 3; i++) {
+        const schuetzenInitialLength = schuetzen[i].length;
+        for (let j = 0; j < (5 - schuetzenInitialLength); j++) {
+          schuetzen[i].push(new PasseDO(null, payload.id, payload.mannschaftId, payload.wettkampfId, payload.nr, j + 1));
         }
       }
     }


### PR DESCRIPTION
Der Vergleichswert für die Zählvariable hatte sich in der forschleife geändert. Dies führt zu einer nicht korrekten Auffüllung von passen und damit zu einer falschen Anzeige