### PR TITLE
Bsapp 536

### DIFF
--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.html
@@ -1,14 +1,29 @@
 <bla-navigation-dialog [config]="config">
-  <div id="descriptionWrapper" style="display: none;">
-      <p>{{'REGIONEN.REGIONEN.DESCRIPTION' | translate}}</p>
-  </div>
-  <div id="descriptionWrapperClose" style="display: none;">
-    <p>{{'REGIONEN.REGIONEN.CLOSE' | translate}}</p>
-  </div>
 
   <bla-col-layout>
+    <div id="searchWrapper">
+      <div class="row">
+        <bla-quicksearch-list (onSelect)="onSelect($event)"
+                              [items]="regionen"
+                              [loading]="loadingRegionen"
+                              [multipleSelections]="!multipleSelections"
+                              [placeholderTranslationKey]="PLACEHOLDER_VAR"
+                              [optionFieldSelector]="'regionName'"
+                              selectionListHeight="15em"
+                              style="width: 50%; flex-grow: 0;">
 
-    <div #chart style="max-width: 100%"></div>
+        </bla-quicksearch-list>
+      </div>
+
+      <div id="descriptionWrapper" style="display: none;">
+        <p>{{'REGIONEN.REGIONEN.DESCRIPTION' | translate}}</p>
+      </div>
+      <div id="descriptionWrapperClose" style="display: none;">
+        <p>{{'REGIONEN.REGIONEN.CLOSE' | translate}}</p>
+      </div>
+
+      <div #chart style="max-width: 100%"></div>
+    </div>
 
     <div id="detailsWrapper" style="display: none;">
       <div id="details">

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.scss
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.scss
@@ -1,0 +1,5 @@
+.row {
+  margin: 20px;
+  display: flex;
+  flex-direction: column;
+}

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
@@ -29,7 +29,7 @@ const chartDetailsSizeMultiplikator = 0.5;
 export class RegionenComponent implements OnInit {
 
   public config = REGIONEN_CONFIG;
-  private regionen: RegionDO[];
+  public regionen: RegionDO[];
   public selectedDTOs: RegionDO[];
   public currentRegionDO: RegionDO;
 

--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.ts
@@ -9,6 +9,7 @@ import {VereinDataProviderService} from '@verwaltung/services/verein-data-provid
 import {LigaDataProviderService} from '@verwaltung/services/liga-data-provider.service';
 import {RegionDataProviderService} from '../../../verwaltung/services/region-data-provider.service';
 import {LigaDO} from '@verwaltung/types/liga-do.class';
+import {RegionDTO} from '@verwaltung/types/datatransfer/region-dto.class';
 import {LigaDTO} from '@verwaltung/types/datatransfer/liga-dto.class';
 import {VereinDTO} from '@verwaltung/types/datatransfer/verein-dto.class';
 import {RoleVersionedDataObject} from '@verwaltung/services/models/roles-versioned-data-object.class';
@@ -29,11 +30,16 @@ export class RegionenComponent implements OnInit {
 
   public config = REGIONEN_CONFIG;
   private regionen: RegionDO[];
-
+  public selectedDTOs: RegionDO[];
   public currentRegionDO: RegionDO;
 
   private selectedVereinDO: VereinDO;
   private selectedLigaDO: LigaDO;
+
+  public PLACEHOLDER_VAR = 'Bitte Region eingeben...';
+  private selectedRegionsId: number;
+  public loadingRegionen = true;
+  public multipleSelections = true;
 
   private ligen: LigaDTO[];
   private vereine: VereinDTO[];
@@ -50,6 +56,7 @@ export class RegionenComponent implements OnInit {
   ngOnInit() {
     this.getDataAndShowSunburst();
     this.currentRegionDO = new RegionDO();
+    this.loadRegionen();
   }
 
   convertDataToTree(currentRegion: RegionDO, allRegions: RegionDO[]): ChartNode {
@@ -144,13 +151,7 @@ export class RegionenComponent implements OnInit {
       this.regionDataProviderService.findById(node.id)
           .then((response: BogenligaResponse<RegionDO>) => {
               this.currentRegionDO = response.payload;
-              this.reloadVereineUndLigen();
-              const details: HTMLInputElement = document.querySelector('#detailsWrapper') as HTMLInputElement;
-              details.style.display = 'block';
-              const desc: HTMLInputElement = document.querySelector('#descriptionWrapper') as HTMLInputElement;
-              desc.style.display = 'none';
-              const desc1: HTMLInputElement = document.querySelector('#descriptionWrapperClose') as HTMLInputElement;
-              desc1.style.display = 'block';
+              this.loadDetails();
             }
           );
     } else {
@@ -221,6 +222,37 @@ export class RegionenComponent implements OnInit {
 
   public getEmptyList(): RoleVersionedDataObject[] {
     return [];
+  }
+
+  // when a Region gets selected from the list
+  public onSelect($event: RegionDO[]): void {
+    this.selectedDTOs = [];
+    this.selectedDTOs = $event;
+    if (!!this.selectedDTOs && this.selectedDTOs.length > 0) {
+      this.selectedRegionsId = this.selectedDTOs[0].id;
+      this.currentRegionDO = this.selectedDTOs[0];
+      this.loadDetails();
+    }
+  }
+
+  // backend-call to get the list of regionen
+  private loadRegionen(): void {
+    this.regionen = [];
+    this.regionDataProviderService.findAll()
+        .then((response: BogenligaResponse<RegionDTO[]>) => {this.regionen = response.payload;  this.loadingRegionen = false; })
+        .catch((response: BogenligaResponse<RegionDTO[]>) => {this.regionen = response.payload; });
+
+  }
+
+  // Loads details for the selected region
+  private loadDetails(): void {
+    this.reloadVereineUndLigen();
+    const details: HTMLInputElement = document.querySelector('#detailsWrapper') as HTMLInputElement;
+    details.style.display = 'block';
+    const desc: HTMLInputElement = document.querySelector('#descriptionWrapper') as HTMLInputElement;
+    desc.style.display = 'none';
+    const desc1: HTMLInputElement = document.querySelector('#descriptionWrapperClose') as HTMLInputElement;
+    desc1.style.display = 'block';
   }
 
 }


### PR DESCRIPTION
Quicksearch-Liste für Regionen hinzugefügt. Man muss für Regionen-Details nun nicht mehr zwangsläufig durch die Scheibe navigieren.