### PR TITLE
BSAPP-640

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/components/sportjahresplan/sportjahresplan.component.html
+++ b/bogenliga/src/app/modules/sportjahresplan/components/sportjahresplan/sportjahresplan.component.html
@@ -50,9 +50,12 @@
   </bla-col-layout>
 
   <bla-col-layout>
-      <h3><BR>Ligatabelle Vorbereitung <BR>&nbsp;</h3>
+    <h3 id="WettkampfTitle"></h3>
   </bla-col-layout>
 
+  <bla-col-layout>
+      <h3><BR>Ligatabelle Vorbereitung <BR>&nbsp;</h3>
+  </bla-col-layout>
 
   <bla-col-layout>
     <div>


### PR DESCRIPTION
Ich habe  die fehlenden Zeilen erneut in sportjahresplan.component.html eingefügt.
Dadurch kann in sportjahresplan.component.ts wieder die id gefunden werden und der [innertext] geladen werden.
Dadurch kann auch die Ligatabelle Durchführung wieder angezeigt werden.