### PR TITLE
Bsapp 647

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.html
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.html
@@ -105,7 +105,7 @@
                            let-passe
                            ngFor>
                 <td *ngIf="j == 0">
-                  <input [(ngModel)]="passe.schuetzeNr"
+                  <input [(ngModel)]="passe.rueckennummer"
                          blaSchuetzeNumberOnly
                          blaSchuetzenTabIndexDirective
                          type="number">
@@ -320,7 +320,7 @@
                            let-passe
                            ngFor>
                 <td *ngIf="j == 0">
-                  <input [(ngModel)]="passe.schuetzeNr"
+                  <input [(ngModel)]="passe.rueckennummer"
                          blaSchuetzeNumberOnly
                          blaSchuetzenTabIndexDirective
                          type="number">

--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -76,7 +76,8 @@ export class SchusszettelComponent implements OnInit {
             .then((data: BogenligaResponse<Array<MatchDOExt>>) => {
               this.match1 = data.payload[0];
               this.match2 = data.payload[1];
-
+              console.log("match1", this.match1);
+              console.log("match2", this.match2);
               let shouldInitSumSatz = true;
               if (this.match1.schuetzen.length <= 0) {
                 this.initSchuetzenMatch1();
@@ -87,6 +88,7 @@ export class SchusszettelComponent implements OnInit {
                 this.initSchuetzenMatch2();
                 shouldInitSumSatz = false;
               }
+
 
               if (shouldInitSumSatz) {
                 this.initSumSatz();
@@ -108,13 +110,13 @@ export class SchusszettelComponent implements OnInit {
    * After that, sets the match's sumSatzx depending on which Satz was edited.
    * @param value
    * @param matchNr
-   * @param schuetzenNr
+   * @param rueckennnummer
    * @param satzNr
    * @param pfeilNr
    */
-  onChange(value: string, matchNr: number, schuetzenNr: number, satzNr: number, pfeilNr: number) {
+  onChange(value: string, matchNr: number, rueckennummer: number, satzNr: number, pfeilNr: number) {
     const match = this['match' + matchNr];
-    const satz = match.schuetzen[schuetzenNr][satzNr];
+    const satz = match.schuetzen[rueckennummer][satzNr];
     let realValue = parseInt(value, 10); // value ist string, ringzahlen sollen number sein -> value in number umwandeln
     realValue = realValue >= 0 ? realValue : null;
     pfeilNr === 1 ? satz.ringzahlPfeil1 = realValue : satz.ringzahlPfeil2 = realValue;
@@ -147,12 +149,12 @@ export class SchusszettelComponent implements OnInit {
     } else if (
       // zum Speichern konsitenteer Daten müssen alle Schützennnummern erfasst sein
       // daher prüfen wir hier ersten auf "leer" d.h. gleich 0
-        this.match1.schuetzen[0][0].schuetzeNr == null ||
-        this.match1.schuetzen[1][0].schuetzeNr == null ||
-        this.match1.schuetzen[2][0].schuetzeNr == null ||
-        this.match2.schuetzen[0][0].schuetzeNr == null ||
-        this.match2.schuetzen[1][0].schuetzeNr == null ||
-        this.match2.schuetzen[2][0].schuetzeNr == null ) {
+        this.match1.schuetzen[0][0].rueckennummer == null ||
+        this.match1.schuetzen[1][0].rueckennummer == null ||
+        this.match1.schuetzen[2][0].rueckennummer == null ||
+        this.match2.schuetzen[0][0].rueckennummer == null ||
+        this.match2.schuetzen[1][0].rueckennummer == null ||
+        this.match2.schuetzen[2][0].rueckennummer == null ) {
       this.notificationService.showNotification({
         id:          'NOTIFICATION_SCHUSSZETTEL_SCHUETZENNUMMER',
         title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.SCHUETZENNUMMER.TITLE',
@@ -165,12 +167,12 @@ export class SchusszettelComponent implements OnInit {
     } else if (
       // und jetzt prüfen wir noch ob in einer Mannschaft die gleiche
       // Schützennummer zweimal angegeben wurde -> auch nicht möglich
-      this.match1.schuetzen[0][0].schuetzeNr === this.match1.schuetzen[1][0].schuetzeNr ||
-      this.match1.schuetzen[1][0].schuetzeNr === this.match1.schuetzen[2][0].schuetzeNr ||
-      this.match1.schuetzen[2][0].schuetzeNr === this.match1.schuetzen[0][0].schuetzeNr ||
-      this.match2.schuetzen[0][0].schuetzeNr === this.match2.schuetzen[1][0].schuetzeNr ||
-      this.match2.schuetzen[1][0].schuetzeNr === this.match2.schuetzen[2][0].schuetzeNr ||
-      this.match2.schuetzen[2][0].schuetzeNr === this.match2.schuetzen[0][0].schuetzeNr ) {
+      this.match1.schuetzen[0][0].rueckennummer === this.match1.schuetzen[1][0].rueckennummer ||
+      this.match1.schuetzen[1][0].rueckennummer === this.match1.schuetzen[2][0].rueckennummer ||
+      this.match1.schuetzen[2][0].rueckennummer === this.match1.schuetzen[0][0].rueckennummer ||
+      this.match2.schuetzen[0][0].rueckennummer === this.match2.schuetzen[1][0].rueckennummer ||
+      this.match2.schuetzen[1][0].rueckennummer === this.match2.schuetzen[2][0].rueckennummer ||
+      this.match2.schuetzen[2][0].rueckennummer === this.match2.schuetzen[0][0].rueckennummer ) {
       this.notificationService.showNotification({
         id:          'NOTIFICATION_SCHUSSZETTEL_SCHUETZENNUMMER',
         title:       'SPORTJAHRESPLAN.SCHUSSZETTEL.NOTIFICATION.SCHUETZENEINDEUTIG.TITLE',
@@ -205,8 +207,8 @@ export class SchusszettelComponent implements OnInit {
           this.match1.schuetzen[i][j].dsbMitgliedId = this.match1.schuetzen[i][0].dsbMitgliedId;
           this.match2.schuetzen[i][j].dsbMitgliedId = this.match2.schuetzen[i][0].dsbMitgliedId;
 
-          this.match1.schuetzen[i][j].schuetzeNr = this.match1.schuetzen[i][0].schuetzeNr;
-          this.match2.schuetzen[i][j].schuetzeNr = this.match2.schuetzen[i][0].schuetzeNr;
+          this.match1.schuetzen[i][j].rueckennummer = this.match1.schuetzen[i][0].rueckennummer;
+          this.match2.schuetzen[i][j].rueckennummer = this.match2.schuetzen[i][0].rueckennummer;
         }
       }
       this.schusszettelService.create(this.match1, this.match2)

--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -215,8 +215,8 @@ export class SchusszettelComponent implements OnInit {
         .then((data: BogenligaResponse<Array<MatchDOExt>>) => {
           this.match1 = data.payload[0];
           this.match2 = data.payload[1];
-          this.initSumSatz();
-          this.setPoints();
+          // neu initialisieren, damit passen die noch keine ID haben eine ID vom Backend erhalten
+          this.ngOnInit();
           this.notificationService.discardNotification();
         }, (error) => {
           console.error(error);

--- a/bogenliga/src/app/modules/sportjahresplan/components/tableteingabe/tableteingabe.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/tableteingabe/tableteingabe.component.ts
@@ -32,7 +32,7 @@ class SchuetzeErgebnisse {
   addPasse() {
     const p = new PasseDO();
     p.lfdNr = this.passen.length + 1;
-    p.schuetzeNr = this.schuetzeNr;
+    p.rueckennummer = this.schuetzeNr;
     this.passen.push(p);
   }
 }
@@ -418,6 +418,6 @@ export class TabletEingabeComponent implements OnInit {
     passe.matchNr = this.currentMatch.nr;
     passe.matchId = this.currentMatch.id;
     passe.wettkampfId = this.currentMatch.wettkampfId;
-    passe.schuetzeNr = schuetze.schuetzeNr;
+    passe.rueckennummer = schuetze.schuetzeNr;
   }
 }

--- a/bogenliga/src/app/modules/sportjahresplan/mapper/match-mapper-ext.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/mapper/match-mapper-ext.ts
@@ -22,24 +22,31 @@ export class MatchMapperExt {
     const schuetzen = [];
     let sumSatz = [];
     if (payload.passen.length > 0) {
+      const schuetzenPasseMap = new Map<number, PasseDO[]>();
       schuetzen[0] = [];
       schuetzen[1] = [];
       schuetzen[2] = [];
       sumSatz = [0, 0, 0, 0, 0];
+      // Map Passen to Schuetzen using rueckennummern
       for (const passe of payload.passen) {
-        switch (passe.schuetzeNr) {
-          case 1:
-            schuetzen[0].push(PasseMapper.passeToDO(passe));
-            break;
-          case 2:
-            schuetzen[1].push(PasseMapper.passeToDO(passe));
-            break;
-          case 3:
-            schuetzen[2].push(PasseMapper.passeToDO(passe));
-            break;
+        const passeDO = PasseMapper.passeToDO(passe);
+        if (!schuetzenPasseMap.has(passe.rueckennummer)) {
+          const passen = [];
+          passen.push(passeDO);
+          schuetzenPasseMap.set(passe.rueckennummer, passen);
+        } else {
+          schuetzenPasseMap.get(passe.rueckennummer).push(passeDO);
         }
-
       }
+      console.log("schuetzenPasseMap", schuetzenPasseMap);
+      // Convert map to array
+      let i = 0;
+      schuetzenPasseMap.forEach((passen, rueckennummer) => {
+        schuetzen[i] = passen;
+        i++;
+      });
+
+      console.log("schuetzen", schuetzen);
 
       for (let i = 0; i < schuetzen[0].length; i++) {
         for (const passen of schuetzen) {
@@ -83,7 +90,7 @@ export class MatchMapperExt {
     const passen = [];
     for (const schuetze of payload.schuetzen) {
       for (const passe of schuetze) {
-        passe.schuetzeNr = schuetze[0].schuetzeNr;
+        passe.rueckennummer = schuetze[0].rueckennummer;
         passen.push(PasseMapper.passeToDTO(passe));
       }
     }

--- a/bogenliga/src/app/modules/sportjahresplan/mapper/passe-mapper.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/mapper/passe-mapper.ts
@@ -17,7 +17,7 @@ export class PasseMapper {
       payload.ringzahl[3],
       payload.ringzahl[4],
       payload.ringzahl[5],
-      payload.schuetzeNr);
+      payload.rueckennummer);
   }
 
   static passeToDTO(payload: PasseDO): PasseDTO {
@@ -37,6 +37,6 @@ export class PasseMapper {
       payload.lfdNr,
       payload.dsbMitgliedId,
       ringzahl,
-      payload.schuetzeNr);
+      payload.rueckennummer);
   }
 }

--- a/bogenliga/src/app/modules/sportjahresplan/services/match-provider.service.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/services/match-provider.service.ts
@@ -27,6 +27,7 @@ export class MatchProviderService extends DataProviderService {
     return new Promise((resolve, reject) => {
       this.restClient.GET<MatchDTOExt>(new UriBuilder().fromPath(this.getUrl()).path(matchId).build())
           .then((data: MatchDTOExt) => {
+
             const matchDO = MatchMapperExt.matchToDO(data);
             resolve({result: RequestResult.SUCCESS, payload: matchDO});
           }, (error: HttpErrorResponse) => {
@@ -44,6 +45,7 @@ export class MatchProviderService extends DataProviderService {
     return new Promise(((resolve, reject) => {
       this.restClient.POST(this.getUrl(), matchDTO)
           .then((data: MatchDTOExt) => {
+
             const newMatchDO = MatchMapperExt.matchToDO(data);
             resolve({result: RequestResult.SUCCESS, payload: newMatchDO});
           }, (error: HttpErrorResponse) => {

--- a/bogenliga/src/app/modules/sportjahresplan/services/schusszettel-provider.service.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/services/schusszettel-provider.service.ts
@@ -26,6 +26,7 @@ export class SchusszettelProviderService extends DataProviderService {
     return new Promise((resolve, reject) => {
       this.restClient.GET<Array<MatchDTOExt>>(new UriBuilder().fromPath(this.getUrl()).path(match1Id).path(match2Id).build())
           .then((data: Array<MatchDTOExt>) => {
+            console.log("data in MatchDTO", data)
             const matches = [MatchMapperExt.matchToDO(data[0]), MatchMapperExt.matchToDO(data[1])];
             resolve({result: RequestResult.SUCCESS, payload: matches});
           }, (error: HttpErrorResponse) => {

--- a/bogenliga/src/app/modules/sportjahresplan/types/datatransfer/passe-dto.class.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/types/datatransfer/passe-dto.class.ts
@@ -11,7 +11,7 @@ export class PasseDTO implements DataTransferObject {
   dsbMitgliedId: number;
 
   ringzahl: Array<number>;
-  schuetzeNr: number;
+  rueckennummer: number;
 
   constructor(id?: number,
               matchId?: number,
@@ -21,7 +21,7 @@ export class PasseDTO implements DataTransferObject {
               lfdNr?: number,
               dsbMitgliedId?: number,
               ringzahl?: Array<number>,
-              schuetzeNr?: number) {
+              rueckennummer?: number) {
     this.id = !!id ? id : null;
     this.matchId = !!matchId ? matchId : null;
     this.mannschaftId = !!mannschaftId ? mannschaftId : null;
@@ -30,6 +30,6 @@ export class PasseDTO implements DataTransferObject {
     this.lfdNr = !!lfdNr ? lfdNr : null;
     this.dsbMitgliedId = !!dsbMitgliedId ? dsbMitgliedId : null;
     this.ringzahl = !!ringzahl ? ringzahl : [];
-    this.schuetzeNr = !!schuetzeNr ? schuetzeNr : null;
+    this.rueckennummer = !!rueckennummer ? rueckennummer : null;
   }
 }

--- a/bogenliga/src/app/modules/sportjahresplan/types/passe-do.class.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/types/passe-do.class.ts
@@ -17,7 +17,7 @@ export class PasseDO implements DataObject {
   ringzahlPfeil5: number;
   ringzahlPfeil6: number;
 
-  schuetzeNr: number;
+  rueckennummer: number;
 
   constructor(id?: number,
               matchId?: number,
@@ -32,7 +32,7 @@ export class PasseDO implements DataObject {
               ringzahlPfeil4?: number,
               ringzahlPfeil5?: number,
               ringzahlPfeil6?: number,
-              schuetzeNr?: number) {
+              rueckennummer?: number) {
     this.id = !!id ? id : null;
     this.matchId = !!matchId ? matchId : null;
     this.mannschaftId = !!mannschaftId ? mannschaftId : null;
@@ -46,6 +46,6 @@ export class PasseDO implements DataObject {
     this.ringzahlPfeil4 = !!ringzahlPfeil4 ? ringzahlPfeil4 : null;
     this.ringzahlPfeil5 = !!ringzahlPfeil5 ? ringzahlPfeil5 : null;
     this.ringzahlPfeil6 = !!ringzahlPfeil6 ? ringzahlPfeil6 : null;
-    this.schuetzeNr = !!schuetzeNr ? schuetzeNr : null;
+    this.rueckennummer = !!rueckennummer ? rueckennummer : null;
   }
 }


### PR DESCRIPTION
Speichern des Schusszettels anpassen

    SchuetzenNr in Rueckennummer umbenannt
    Passen werden jetzt je zur Rueckennummer gemappt und nicht einfach in die 3 ersten Schützen

~MatchService: Fehlerhaftes logging entfernt, logging hinzu, Schreibfehler korrigiert
~MannschaftsmitgliedDAO: fehlerhafte Methode "update" gefixt
~schusszettel.component.ts: initialisieren der Seite nach speichern der Daten, damit neu erstellte passen im frontend die vom Backend zugewiesene ID erhalten
~PasseService, MatchsService, BogenkontrolllisteComponentImpl, MeldezettelComponentImpl, MannschaftsmitgliedComponent, MannschaftsmitgliedDAO: 
Methode umbenannt in findAllSchuetzenInTeamEingesetzt (findAllSchuetzenInTeam hat nur die Schuetzen zurückgeliefert welche auch bereits einmal eingesetzt wurden)
Methode umbenannt in findAllSchuetzen (findAllSchuetzenGemeldet hat alle Schützen die einem Team zugewiesen sind zurückgemeldet)