### PR TITLE
BSAPP-677

### DIFF
--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
@@ -119,11 +119,6 @@ export class LigatabelleComponent extends CommonComponent implements OnInit {
     if (this.selectedVeranstaltungId != null) {
       this.loadLigaTableRows();
     }
-    this.rowsLigatabelle = [];
-    this.tableContent = [];
-    if (this.selectedVeranstaltungId != null) {
-      this.loadLigaTableRows();
-    }
   }
 
 // backend-call to get the list of veranstaltungen


### PR DESCRIPTION
~ ligatabelle.component.ts
~ changeVeranstaltung()
- doppelter Aufruff von loadLigaTabeleRows() entfernt

Problem war eine Code Dopplung die zum zweimaligen laden der Vereine (Tabellenplätze) geführt hat.