### PR TITLE
~ Making Sunburst hovertext readable

### DIFF
--- a/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.scss
+++ b/bogenliga/src/app/modules/regionen/components/regionen/regionen.component.scss
@@ -3,3 +3,7 @@
   display: flex;
   flex-direction: column;
 }
+
+/deep/ .sunburst-tooltip {
+  max-width: none;
+}


### PR DESCRIPTION
Der Hovertext des Sunburst ist nun lesbar (Der ganze Text wird jetzt mit dem dunklen Hintergrund dargestellt).