### PR TITLE
BSAPP-623 Implementierung

### DIFF
--- a/bogenliga/src/app/app.routing.ts
+++ b/bogenliga/src/app/app.routing.ts
@@ -7,6 +7,7 @@ export const ROUTES: Routes = [
   {path: 'home', component: HomeComponent},
   {path: 'wettkaempfe', loadChildren: () => import('src/app/modules/wettkampf/wettkampf.module').then((m) => m.WettkampfModule)},
   {path: 'wettkaempfe/:id', loadChildren: () => import('src/app/modules/wettkampf/wettkampf.module').then((m) => m.WettkampfModule)},
+  {path: 'wettkaempfe/:id/:id', loadChildren: () => import('src/app/modules/wettkampf/wettkampf.module').then((m) => m.WettkampfModule)},
   {path: 'verwaltung', loadChildren: () => import('src/app/modules/verwaltung/verwaltung.module').then((m) => m.VerwaltungModule)},
   {
     path: 'sportjahresplan',

--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
@@ -184,7 +184,7 @@ export class LigatabelleComponent extends CommonComponentDirective implements On
     this.loadingLigatabelle = false;
   }
   public ligatabelleLinking() {
-    const link = '/wettkaempfe/' + this.selectedVeranstaltungName;
+    const link = '/wettkaempfe/' + this.selectedVeranstaltungId;
     this.router.navigateByUrl(link);
   }
 

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.html
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.html
@@ -35,13 +35,15 @@
   <tbody *ngIf="!isLoading() && !isEmptyTable()">
   <tr *ngFor="let row of rows"
       [id]="getRowId(row)"
-      (click)="hasActions() == false && onRowClicked(row.payload)"
+      (click)="hasActions() == true && onRowClicked(row.payload)"
       [style.cursor]="!hasActions() ? 'pointer' : 'default'"
       [class.disabled]="hasLoadingActions(row)"> <!-- Click event is only active if table has no action items -->
 
     <!-- data columns -->
     <td *ngFor="let column of config.columns"
         [id]="getCellId(row, column)"
+        (click)="onColumnClicked(column)"
+        [style.cursor]="'pointer'"
         [ngSwitch]="column.type"
         [class]="getStyleClass(row, column)">
 

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -38,6 +38,8 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   @Output() public onDownloadRueckennummerEntry = new EventEmitter<VersionedDataObject>();
   @Output() public onDownloadLizenzenEntry = new EventEmitter<VersionedDataObject>();
 
+  @Output() public onColumnEntry = new EventEmitter<TableColumnConfig>();
+
   // do not remove, the view uses this enum
   public TableColumnType = TableColumnType;
 
@@ -344,6 +346,10 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
 
   private onRowClicked(affectedRowPayload: VersionedDataObject) {
     this.onRowEntry.emit(affectedRowPayload);
+  }
+
+  private onColumnClicked(affectedColumn: TableColumnConfig) {
+    this.onColumnEntry.emit(affectedColumn)
   }
 
   private onDownload(affectedRowPayload: VersionedDataObject) {

--- a/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
+++ b/bogenliga/src/app/modules/shared/components/tables/data-table/data-table.component.ts
@@ -349,7 +349,7 @@ export class DataTableComponent extends CommonComponentDirective implements OnIn
   }
 
   private onColumnClicked(affectedColumn: TableColumnConfig) {
-    this.onColumnEntry.emit(affectedColumn)
+    this.onColumnEntry.emit(affectedColumn);
   }
 
   private onDownload(affectedRowPayload: VersionedDataObject) {

--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.html
@@ -25,6 +25,8 @@
                     [loading]="loadingTable"
                     [rows]="rows"
 
+                    (onColumnEntry)="getSelectedColumn($event)"
+                    (onRowEntry)="getSelectedRow($event)"
                     (onMapEntry)="onMap($event)">
       <!-- Is currently not in use/implemented
                     (onDeleteClicked)="onDelete($event)"

--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
@@ -49,7 +49,7 @@ export class VereineComponent extends CommonComponentDirective implements OnInit
   private providedID: number;
   private currentVerein: VereinDO;
   private hasID: boolean;
-  private typeOfTableColumn: String;
+  private typeOfTableColumn: string;
 
   constructor(private router: Router,
               private route: ActivatedRoute,
@@ -171,29 +171,29 @@ export class VereineComponent extends CommonComponentDirective implements OnInit
     const rowValues = $event;
     const veranstalungsName = rowValues.veranstaltung_name;
     let veranstalungsId;
-    const mannschaftsName = rowValues.mannschaftsName.replace(". Mannschaft", "");
+    const mannschaftsName = rowValues.mannschaftsName.replace('. Mannschaft', '');
     let mannschaftsId;
     const type = this.typeOfTableColumn;
 
 
-      if(type === "veranstaltung_name") {
-        veranstalungsId = await this.getCurrentVeranstalung(veranstalungsName);
-        this.vereineLinking(veranstalungsId);
-      } else if(type === "mannschaftsName") {
-        veranstalungsId = await this.getCurrentVeranstalung(veranstalungsName);
-        /**
-         * finds all Mannschaften through a http call -> needs to be async
-         * find the one whose name matches with the mannschaft in the table
-         * gets the id from this mannschaft
-         */
-        await this.mannschaftsDataProvider.findAll()
-                  .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => {
-                    const currentMannschaft = response.payload.find(mannschaft => mannschaft.name === mannschaftsName)
-                    mannschaftsId = currentMannschaft.id;
-                  })
-        this.vereineLinking(veranstalungsId + "/" + mannschaftsId);
-      }
+    if (type === 'veranstaltung_name') {
+      veranstalungsId = await this.getCurrentVeranstalung(veranstalungsName);
+      this.vereineLinking(veranstalungsId);
+    } else if (type === 'mannschaftsName') {
+      veranstalungsId = await this.getCurrentVeranstalung(veranstalungsName);
+      /**
+       * finds all Mannschaften through a http call -> needs to be async
+       * find the one whose name matches with the mannschaft in the table
+       * gets the id from this mannschaft
+       */
+      await this.mannschaftsDataProvider.findAll()
+                .then((response: BogenligaResponse<DsbMannschaftDTO[]>) => {
+                  const currentMannschaft = response.payload.find((mannschaft: DsbMannschaftDTO) => mannschaft.name === mannschaftsName);
+                  mannschaftsId = currentMannschaft.id;
+                });
+      this.vereineLinking(veranstalungsId + '/' + mannschaftsId);
     }
+  }
 
   /**
    * finds all Veranstaltungen through a http call -> needs to be async
@@ -204,9 +204,9 @@ export class VereineComponent extends CommonComponentDirective implements OnInit
     let currentVeranstalung;
     await this.veranstaltungsDataProvider.findAll()
         .then((response: BogenligaResponse<VeranstaltungDTO[]>) => {
-          currentVeranstalung = response.payload.find(veranstalung => veranstalung.name = veranstalungsName)
+          currentVeranstalung = response.payload.find((veranstalung: VeranstaltungDTO) => veranstalung.name = veranstalungsName);
           console.log(currentVeranstalung.ligaId);
-        })
+        });
     return currentVeranstalung.ligaId;
   }
 

--- a/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
+++ b/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
@@ -74,13 +74,11 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
     this.route.params.subscribe((params) => {
 
 
-      if(!isUndefined(params['Wettkampf']) && !isUndefined(params['Mannschaft'])) {
-        this.directWettkampf = parseInt(params['Wettkampf']);
-        this.directMannschaft = parseInt(params['Mannschaft']);
-      }
-
-      else if (!isUndefined(params['Wettkampf'])) {
-        this.directWettkampf = parseInt(params['Wettkampf']);
+      if (!isUndefined(params['Wettkampf']) && !isUndefined(params['Mannschaft'])) {
+        this.directWettkampf = parseInt(params['Wettkampf'], 10);
+        this.directMannschaft = parseInt(params['Mannschaft'], 10);
+      } else if (!isUndefined(params['Wettkampf'])) {
+        this.directWettkampf = parseInt(params['Wettkampf'], 10);
       }
 
     });
@@ -88,8 +86,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
               .then(() => {
                 console.log(this.currentMannschaft);
                 this.loadErgebnisse(this.currentMannschaft);
-              })
-
+              });
   }
 
   /**

--- a/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
+++ b/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
@@ -19,6 +19,7 @@ import {PasseDoClass} from '@verwaltung/types/passe-do-class';
 import {VeranstaltungDO} from '@verwaltung/types/veranstaltung-do.class';
 import {VereinDO} from '@verwaltung/types/verein-do.class';
 import {MatchDO} from '@verwaltung/types/match-do.class';
+import {NotificationService} from '@shared/services';
 
 const ID_PATH_PARAM = 'id';
 @Component({
@@ -60,7 +61,8 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
               private wettkampfErgebnisService: WettkampfErgebnisService,
               private mannschaftDataProvider: DsbMannschaftDataProviderService,
               private router: Router,
-              private route: ActivatedRoute) {
+              private route: ActivatedRoute,
+              private notificationService: NotificationService) {
     super();
   }
 
@@ -70,12 +72,17 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
    */
   ngOnInit() {
     this.route.params.subscribe((params) => {
-      if (!isUndefined(params[ID_PATH_PARAM])) {
-        const id = params[ID_PATH_PARAM];
-        this.directWettkampf = id;
-        this.directMannschaft = id;
-        this.directMannschaft = this.directMannschaft.replace(/-/g, ' ');
+
+
+      if(!isUndefined(params['Wettkampf']) && !isUndefined(params['Mannschaft'])) {
+        this.directWettkampf = parseInt(params['Wettkampf']);
+        this.directMannschaft = parseInt(params['Mannschaft']);
       }
+
+      else if (!isUndefined(params['Wettkampf'])) {
+        this.directWettkampf = parseInt(params['Wettkampf']);
+      }
+
     });
     this.loadVeranstaltungen();
   }
@@ -123,13 +130,15 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
         .then((response: BogenligaResponse<VeranstaltungDO[]>) => this.handleSuccessLoadVeranstaltungen(response))
         .catch((response: BogenligaResponse<VeranstaltungDO[]>) => this.veranstaltungen = []);
 
+
   }
+
 
   handleSuccessLoadVeranstaltungen(response: BogenligaResponse<VeranstaltungDO[]>) {
     this.veranstaltungen = response.payload;
     if (this.directWettkampf != null) {
       for (const i of this.veranstaltungen) {
-        if (this.directWettkampf === i.name) {
+        if (this.directWettkampf === i.ligaId) {
           this.currentVeranstaltung = i;
           break;
         }
@@ -155,7 +164,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
     this.mannschaften = response.payload;
     if (this.directMannschaft != null) {
       for (const i of this.mannschaften) {
-        if (this.directMannschaft === i.name) {
+        if (this.directMannschaft === i.id) {
           this.mannschaften[0] = i;
         }
         this.currentMannschaft = this.mannschaften[0];

--- a/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
+++ b/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
@@ -70,7 +70,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
    * Gets the value from path if Wettkampfergebnisse page is called. Starts after than loading of all Veranstaltungen
    * @see this.loadVeranstaltungen
    */
-  ngOnInit() {
+  async ngOnInit() {
     this.route.params.subscribe((params) => {
 
 
@@ -84,7 +84,12 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
       }
 
     });
-    this.loadVeranstaltungen();
+    await this.loadVeranstaltungen()
+              .then(() => {
+                console.log(this.currentMannschaft);
+                this.loadErgebnisse(this.currentMannschaft);
+              })
+
   }
 
   /**
@@ -125,8 +130,8 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
   }
 
   // backend-calls to get data from DB
-  public loadVeranstaltungen() {
-    this.veranstaltungsDataProvider.findAll()
+  public async loadVeranstaltungen() {
+    await this.veranstaltungsDataProvider.findAll()
         .then((response: BogenligaResponse<VeranstaltungDO[]>) => this.handleSuccessLoadVeranstaltungen(response))
         .catch((response: BogenligaResponse<VeranstaltungDO[]>) => this.veranstaltungen = []);
 
@@ -134,7 +139,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
   }
 
 
-  handleSuccessLoadVeranstaltungen(response: BogenligaResponse<VeranstaltungDO[]>) {
+  async handleSuccessLoadVeranstaltungen(response: BogenligaResponse<VeranstaltungDO[]>) {
     this.veranstaltungen = response.payload;
     if (this.directWettkampf != null) {
       for (const i of this.veranstaltungen) {
@@ -151,7 +156,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
     this.currentJahr = this.currentVeranstaltung.sportjahr;
     this.loadMannschaft(this.currentVeranstaltung.id);
     this.loadJahre();
-    this.loadWettkaempfe(this.currentVeranstaltung.id);
+    await this.loadWettkaempfe(this.currentVeranstaltung.id);
   }
 
   public loadMannschaft(veranstaltungsId: number) {
@@ -171,7 +176,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
       }
     } else if (this.currentMannschaft !== null) {
 
-      this.currentMannschaft = this.mannschaften[0];
+      this.currentMannschaft = undefined;
     }
   }
 
@@ -183,8 +188,8 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
     }
   }
 
-  public loadWettkaempfe(veranstaltungsId: number) {
-    this.wettkampfDataProviderService.findAllByVeranstaltungId(veranstaltungsId)
+  public async loadWettkaempfe(veranstaltungsId: number) {
+    await this.wettkampfDataProviderService.findAllByVeranstaltungId(veranstaltungsId)
         .then((response: BogenligaResponse<WettkampfDO[]>) => this.handleLoadWettkaempfe(response.payload))
         .catch((response: BogenligaResponse<VereinDO[]>) => this.handleLoadWettkaempfe([]));
   }
@@ -194,29 +199,28 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
    * WettkampfErgebnisse are put in correct order into this.rows
    * @param wettkaempfe the amount of wettkaempfe of one Veranstaltung
    */
-  public handleLoadWettkaempfe(wettkaempfe: WettkampfDO[]) {
+  public async  handleLoadWettkaempfe(wettkaempfe: WettkampfDO[]) {
     this.wettkaempfe = this.wettkaempfe.concat(wettkaempfe);
     for (let index = 0; index < this.wettkaempfe.length; index++) {
       this.loadingData = true;
-      this.loadMatches(this.wettkaempfe[index].id, index);
+      await this.loadMatches(this.wettkaempfe[index].id, index);
     }
   }
 
-  public loadMatches(wettkampfId: number, index: number) {
-
-    this.matchDataProviderService.findByWettkampfId(wettkampfId)
+  public async  loadMatches(wettkampfId: number, index: number) {
+    await this.matchDataProviderService.findByWettkampfId(wettkampfId)
         .then((response: BogenligaResponse<MatchDO[]>) => this.handleSuccessLoadMatches(response.payload, wettkampfId, index))
         .catch((response: BogenligaResponse<MatchDO[]>) => this.handleSuccessLoadMatches([], wettkampfId, index));
   }
 
 
-  public handleSuccessLoadMatches(matches: MatchDO[], wettkampfId: number, index: number) {
+  public async  handleSuccessLoadMatches(matches: MatchDO[], wettkampfId: number, index: number) {
     this.matches[index] = matches;
-    this.loadPassen(wettkampfId, matches, index);
+    await this.loadPassen(wettkampfId, matches, index);
   }
 
-  public loadPassen(wettkampfId: number, matches: MatchDO[], index: number) {
-    this.passeDataProviderService.findByWettkampfId(wettkampfId)
+  public async loadPassen(wettkampfId: number, matches: MatchDO[], index: number) {
+    await this.passeDataProviderService.findByWettkampfId(wettkampfId)
         .then((response: BogenligaResponse<PasseDoClass[]>) => this.handleSuccessLoadPassen(response.payload, matches, index))
         .catch((response: BogenligaResponse<PasseDoClass[]>) => this.handleSuccessLoadPassen([], matches, index));
   }

--- a/bogenliga/src/app/modules/wettkampf/wettkampf.routing.ts
+++ b/bogenliga/src/app/modules/wettkampf/wettkampf.routing.ts
@@ -6,5 +6,6 @@ import {WettkampfErgebnisService} from '@wettkampf/services/wettkampf-ergebnis.s
 
 export const WETTKAMPF_ROUTES: Routes = [
   {path: '' , pathMatch: 'full', component: WettkampfComponent},
-  {path: '/:id' , pathMatch: 'full', component: WettkampfComponent},
+  {path: ':Wettkampf' , pathMatch: 'full', component: WettkampfComponent},
+  {path: ':Wettkampf/:Mannschaft' , pathMatch: 'full', component: WettkampfComponent},
 ];


### PR DESCRIPTION
**Implementierung des Subtasks BSAPP-623 und BSAPP-631 aus dem Haupttask BSAPP-460**

- Weiterleitung von Vereine zu Wettkampf implementiert
         Wenn man auf Wettkampf oder Wettkampftag-Spalte drückt wird man zu Wettkämpfe im entsprechenden Wettkampf 
         weitergeleitet, wenn man auf die Mannschaftsspalte drückt wird man zu Wettkampf mit ausgewähltem Wettkampf UND 
         ausgewählter Mannschaft weitergeleitet.

- Routing wurde verändert, NgOnInit-Funktion in Wettkampf umgeschrieben, um eine URL mit 2 Elementen in Reihenfolge 
   /Wettkampf/Mannschaft  anzunehmen.

- Tabelle wurde Klickbar gemacht, bei Klick wurd URL mit Wettkampfs- und Mannschafts-ID übergeben

- Weiterleitung von Ligatabelle zu Wettkampf funktioniert nun und übergibt einen ausgewählten Wettkampf per ID, der 
   automatisch in Wettkampf ausgewählt ist.

