### PR TITLE
Bsapp-693 Login Button wechselt nach erfolgreicher Anmeldung nicht zu Logout

### DIFF
--- a/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
+++ b/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
@@ -55,8 +55,7 @@ export class CurrentUserService {
     const currentUserValue = this.localDataProviderService.get(CURRENT_USER_KEY);
 
     // Track the default user
-    let isDefault : boolean;
-    
+    let isDefault: boolean;
     if (currentUserValue != null) {
       // Map the permissions from the redux to its values
       const currentUserJSONMap = JSON.parse(currentUserValue);

--- a/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
+++ b/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
@@ -34,26 +34,29 @@ export class CurrentUserService {
               private router: Router) {
     this.observeUserState();
     this.observeSessionExpiredNotifications();
-    this.loadCurrentUser(true);
+    this.loadCurrentUser();
   }
 
   public disableDefaultUser(): void {
     this.isDefaultUserLoggedIn = false;
   }
 
-  public persistCurrentUser(currentUser: UserSignInDTO, isDefault: boolean): void {
+  public persistCurrentUser(currentUser: UserSignInDTO): void {
     this.localDataProviderService.setPermanently(CURRENT_USER_KEY, JSON.stringify(currentUser));
     this.store.dispatch(new Login(currentUser, this.isDefaultUserLoggedIn));
     // load current User after persisting the token
-    this.loadCurrentUser(isDefault);
+    this.loadCurrentUser();
   }
 
-  public loadCurrentUser(isDefault: boolean): void {
+  public loadCurrentUser(): void {
     this.observeSessionExpiredNotifications();
     this.currentUserPermissions = [];
     console.log('Load current user from storage');
     const currentUserValue = this.localDataProviderService.get(CURRENT_USER_KEY);
 
+    // Track the default user
+    let isDefault : boolean;
+    
     if (currentUserValue != null) {
       // Map the permissions from the redux to its values
       const currentUserJSONMap = JSON.parse(currentUserValue);

--- a/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
+++ b/bogenliga/src/app/modules/shared/services/current-user/current-user.service.ts
@@ -63,7 +63,14 @@ export class CurrentUserService {
           this.currentUserPermissions.push(userPermit);
         });
       }
-      this.store.dispatch(new Login(UserSignInDTO.copyFromJson(JSON.parse(currentUserValue)), isDefault));
+      const json = UserSignInDTO.copyFromJson(JSON.parse(currentUserValue));
+      // At this point we cannot be sure if the user is default or not, so we check the raw json directly
+      if (json.email === DEFAULT_USERNAME) {
+        isDefault = true;
+      } else {
+        isDefault = false;
+      }
+      this.store.dispatch(new Login(json, isDefault));
     }
     console.log('CurrentUserValue: ' + currentUserValue);
     console.log('CurrentUserPermission: ' + this.currentUserPermissions);

--- a/bogenliga/src/app/modules/user/components/login/login.component.ts
+++ b/bogenliga/src/app/modules/user/components/login/login.component.ts
@@ -68,7 +68,7 @@ export class LoginComponent implements OnInit {
   public onLogin($event: any): void {
     this.loading = true;
     this.currentUserService.disableDefaultUser();
-    this.loginDataProviderService.signIn(this.credentials, false)
+    this.loginDataProviderService.signIn(this.credentials)
         .then(
           () => this.handleSuccessfulLogin(),
           (loginResult: LoginResult) => this.showFailedLogin(loginResult)

--- a/bogenliga/src/app/modules/user/services/login-data-provider.service.ts
+++ b/bogenliga/src/app/modules/user/services/login-data-provider.service.ts
@@ -45,7 +45,7 @@ export class LoginDataProviderService extends DataProviderService {
    * resolve(), if the request was successful
    * reject(), if an error occurred
    */
-  public signIn(credentialsDO: CredentialsDO, isDefault: boolean): Promise<LoginResult> {
+  public signIn(credentialsDO: CredentialsDO): Promise<LoginResult> {
     // check remember me flag
     if (credentialsDO.rememberMe) {
       this.currentUserService.rememberUsername(credentialsDO.username);
@@ -58,7 +58,7 @@ export class LoginDataProviderService extends DataProviderService {
     // sign in failure -> reject promise with result
     return new Promise((resolve, reject) => {
       const credentialsDTO = new CredentialsDTO(credentialsDO.username, credentialsDO.password, null, credentialsDO.using2FA, credentialsDO.code);
-      this.sendSignInRequest(credentialsDTO, resolve, reject, isDefault);
+      this.sendSignInRequest(credentialsDTO, resolve, reject);
     });
   }
 
@@ -69,12 +69,12 @@ export class LoginDataProviderService extends DataProviderService {
   /**
    * I send the request and handle the response
    */
-  private sendSignInRequest(credentialsDTO: CredentialsDTO, resolve, reject, isDefault: boolean) {
+  private sendSignInRequest(credentialsDTO: CredentialsDTO, resolve, reject) {
 
     this.restClient.POST<UserSignInDTO>(new UriBuilder().fromPath(this.getUrl()).build(), credentialsDTO)
         .then((data: UserSignInDTO) => {
           // store user details and jwt token in local storage to keep user logged in between page refreshes
-          this.currentUserService.persistCurrentUser(data, isDefault);
+          this.currentUserService.persistCurrentUser(data);
           resolve(LoginResult.SUCCESS);
 
         }, (error: HttpErrorResponse) => {
@@ -93,6 +93,6 @@ export class LoginDataProviderService extends DataProviderService {
   // signs in the Default user and returns the Promise
   signInDefaultUser(): Promise<LoginResult> {
     const defaultUserCredentials: CredentialsDO = new CredentialsDO('ligadefault', 'user');
-    return this.signIn(defaultUserCredentials, true);
+    return this.signIn(defaultUserCredentials);
   }
 }

--- a/bogenliga/src/app/modules/user/services/login-data-provider.service.ts
+++ b/bogenliga/src/app/modules/user/services/login-data-provider.service.ts
@@ -1,4 +1,3 @@
-import { AccessCodeDTO } from './../types/model/access-code-dto';
 import { CredentialsDTO } from '@user/types/model/credentials-dto.class';
 import {Injectable} from '@angular/core';
 


### PR DESCRIPTION
Im letzten Sprint wurde das Problem des nicht angezeigten Logout Buttons nach erfolgreichem Login gelöst (Commit: 9ef8ffc).
Ein weiteres damit verbundenes Problem entstand durch die Tatsache, dass nach einem manuellen Reload einer beliebigen Seite nach erfolgreicher Anmeldung der Logout Button wieder verschwand. Im Hintergrund war der jeweilige Benutzer zwar noch angemeldet, jedoch wurde "isdefaultUserLoggedIn" durch den Reload (und damit verbundenem Aufruf der Funktion  "loadCurrentUser()") auf "true" gesetzt und somit die Anzeigelogik des Logout Buttons beeinflusst.

Das Problem wurde gelöst, indem in der Funktion "LoadCurrentUser()" eine Abfrage hinzugefügt wurde, die die Email des aktuell eingeloggten Users mit den Default-User-Daten vergleicht und dementsprechend isDeafault setzt.