### PR TITLE
BSAPP-460:

### DIFF
--- a/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
+++ b/bogenliga/src/app/modules/ligatabelle/components/ligatabelle/ligatabelle.component.ts
@@ -44,14 +44,11 @@ export class LigatabelleComponent extends CommonComponentDirective implements On
   public PLACEHOLDER_VAR = 'Zur Suche Liga-Bezeichnung eingeben...';
   public selectedVeranstaltungId: number;
   public selectedVeranstaltungName: string;
-  private selectedVeranstaltung: VeranstaltungDO;
   public selectedDTOs: VeranstaltungDO[];
   public multipleSelections = true;
   public veranstaltungen: VeranstaltungDO[];
-  public loadingYear: boolean;
   public ligen: LigaDO[];
   public selectedLigen: LigaDO[];
-  public zwVeranstaltung: VeranstaltungDTO;
   public loadingVeranstaltungen = true;
   public loadingLigatabelle = false;
   public rowsLigatabelle: TableRow[];

--- a/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
+++ b/bogenliga/src/app/modules/vereine/components/vereine/vereine.component.ts
@@ -204,7 +204,7 @@ export class VereineComponent extends CommonComponentDirective implements OnInit
    * mannschaftsName: string -  value of the Mannschaft of the selected row
    */
   public linkPreperation(type: string, veranstaltungsName: string, mannschaftsName: string): void {
-    const currentVeranstaltung = this.veranstaltungen.find((veranstalung: VeranstaltungDTO) => veranstalung.name = veranstaltungsName);
+    const currentVeranstaltung = this.veranstaltungen.find((veranstalung: VeranstaltungDTO) => veranstalung.name === veranstaltungsName);
     if (type === 'veranstaltung_name') {
       this.vereineLinking(currentVeranstaltung.id.toString(10));
     } else if (type === 'mannschaftsName') {

--- a/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
+++ b/bogenliga/src/app/modules/wettkampf/components/wettkampf/wettkampf.component.ts
@@ -203,7 +203,7 @@ export class WettkampfComponent extends CommonComponentDirective implements OnIn
     this.veranstaltungen = response.payload;
     if (this.directWettkampf != null) {
       for (const i of this.veranstaltungen) {
-        if (this.directWettkampf === i.ligaId) {
+        if (this.directWettkampf === i.id) {
           this.currentVeranstaltung = i;
           break;
         }


### PR DESCRIPTION
Subtask 623&631

Weiterleitung von Vereine zu Wettkämpfe und Weiterleitung von Ligatabelle zu Wettkämpfe hat unabhängig von der auswählten Liga die WettkampfID 0 übergeben.
Dieses Fehlverhalten wurde gefixed.

Gelöst von Andreas Bausch und Robin Leber