### PR TITLE
Problem mit den unendlich Ladenden Button wurde glöst

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-detail/dsb-mitglied-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/dsb-mitglied/dsb-mitglied-detail/dsb-mitglied-detail.component.ts
@@ -227,6 +227,7 @@ export class DsbMitgliedDetailComponent extends CommonComponentDirective impleme
                 });
 
             this.notificationService.showNotification(notification);
+            this.saveLoading = false;
           }
           this.saveLoading = false;
         });

--- a/bogenliga/src/app/modules/verwaltung/components/liga/liga-detail/liga-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/liga/liga-detail/liga-detail.component.ts
@@ -179,6 +179,7 @@ export class LigaDetailComponent extends CommonComponentDirective implements OnI
                 });
 
             this.notificationService.showNotification(notification);
+            this.saveLoading = false;
           }
         }, (response: BogenligaResponse<LigaDO>) => {
           console.log('Failed');

--- a/bogenliga/src/app/modules/verwaltung/components/region/region-detail/region-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/region/region-detail/region-detail.component.ts
@@ -167,6 +167,7 @@ export class RegionDetailComponent extends CommonComponentDirective implements O
                 });
 
             this.notificationService.showNotification(notification);
+            this.saveLoading = false;
           }
         }, (response: BogenligaResponse<DsbMitgliedDO>) => {
           console.log('Failed');

--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/veranstaltung-detail.component.ts
@@ -304,6 +304,7 @@ export class VeranstaltungDetailComponent extends CommonComponentDirective imple
                 });
 
             this.notificationService.showNotification(notification);
+            this.saveLoading = false;
           }
         }, (response: BogenligaResponse<VeranstaltungDO>) => {
           console.log('Failed');

--- a/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-detail/wettkampfklasse-detail.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/wettkampfklasse/wettkampfklasse-detail/wettkampfklasse-detail.component.ts
@@ -134,6 +134,7 @@ export class WettkampfklasseDetailComponent extends CommonComponentDirective imp
                 });
 
             this.notificationService.showNotification(notification);
+            this.saveLoading = false;
           }
         }, (response: BogenligaResponse<WettkampfKlasseDO>) => {
           console.log('Failed');


### PR DESCRIPTION
BSAPP-782: Wettkampfverwaltung: "Ladezeichen" läuft auch nach Erledigung des Requests weiter

Durch hinzufügen der Codezeile in den einzelnen Dateien wird der Status des Buttons nach Erledigung des Requests wieder auf seinen Ursprünglichen zustand gesetzt und zeigt nicht weiter das Ladende icon an.