### PR TITLE
Testfälle ergänzt und doppelte Funktionen gelöscht

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/services/match-provider.service.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/services/match-provider.service.ts
@@ -81,7 +81,7 @@ export class MatchProviderService extends DataProviderService {
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findAllWettkampfMatchesAndName/wettkampfid=' + id).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findByWettkampfId/wettkampfid=' + id).build())
         .then((data: VersionedDataTransferObject[]) => {
           resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
         }, (error: HttpErrorResponse) => {

--- a/bogenliga/src/app/modules/verwaltung/services/match-data-provider.service.ts
+++ b/bogenliga/src/app/modules/verwaltung/services/match-data-provider.service.ts
@@ -51,7 +51,7 @@ export class MatchDataProviderService extends DataProviderService {
     // sign in success -> resolve promise
     // sign in failure -> reject promise with result
     return new Promise((resolve, reject) => {
-      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findAllWettkampfMatches/wettkampfid=' + id).build())
+      this.restClient.GET<Array<VersionedDataTransferObject>>(new UriBuilder().fromPath(this.getUrl()).path('findByWettkampfId/wettkampfid=' + id).build())
         .then((data: VersionedDataTransferObject[]) => {
           resolve({result: RequestResult.SUCCESS, payload: fromPayloadArray(data)});
         }, (error: HttpErrorResponse) => {


### PR DESCRIPTION
Im Backend sind zwei Duplikate eines bestehenden Interfaces entfallen und die beiden Stelle des Aufrufs werden hiermit auf das verbleibende Interface umgestellt.