### PR TITLE
BSAPP-941: Bugfix and functionality

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.ts
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.ts
@@ -199,6 +199,9 @@ export class WettkampftageComponent extends CommonComponentDirective implements 
     let currentWettkampfTag: WettkampfDO;
     let currentAusrichter: UserProfileDO;
 
+    this.loadWettkampf();
+    this.currentWettkampftagArray.forEach(element => {if(element.wettkampfTag == wettkampfTagNumber){currentWettkampfTag = element;}});
+
     currentWettkampfTag = this.currentWettkampftagArray[wettkampfTagNumber];
     currentAusrichter = this.currentAusrichter[wettkampfTagNumber];
     currentWettkampfTag.wettkampfTag = wettkampfTagNumber;
@@ -401,6 +404,7 @@ export class WettkampftageComponent extends CommonComponentDirective implements 
     this.notificationService.discardNotification();
 
     const id = this.currentWettkampftagArray[wettkampfTagNumber].id;
+    this.updateNumbersDelete(); 
 
     let currentDate = new Date();
     let deadlineDate = new Date(this.currentVeranstaltung.meldeDeadline);
@@ -737,24 +741,32 @@ export class WettkampftageComponent extends CommonComponentDirective implements 
     return true;
   }
 
-  //Wettkampftag der gelöscht werden soll, muss hier übergeben werden
-  public async updateNumbersDelete(wettkampftagToDelete:number){
+  //Wenn nicht alle Felder von allen Wettkampftagen befüllt sind, gibt es einen Error
+  public async updateNumbersDelete(): Promise<boolean>{
+    //TODO Alle existierende Wettkampftage müssen komplett ausgefüllt und abgespeichert sein, Wenn ein Attribut fehlt, funktioniert die Updatefunktion nicht
+
+    this.loadWettkampf();
     this.loadDistinctWettkampf();
 
-    if(wettkampftagToDelete==this.selectedDTOs.length){
-      this.selectedDTOs.pop();
-    }
-    else {
-      //Eig wettkampftagToDelete + 1 aber Array startet bei 0
-      for (let i = wettkampftagToDelete; i <= this.selectedDTOs.length; i++) {
-        this.selectedDTOs[i].wettkampfTag = (this.selectedDTOs[i].wettkampfTag)-1;
-        this.selectedDTOs[i].id = (this.selectedDTOs[i].id) -1;
-        this.selectedDTOs[i - 1] = this.selectedDTOs[i];
+    if(this.selectedWettkampfTag!=this.currentWettkampftagArray.length){    //Wenn letzter Wettkampftag gelöscht werden soll, muss Nummerierung nicht angepasst werden
+      for (let i = this.selectedWettkampfTag +1; i < this.currentWettkampftagArray.length; i++) {   //Man beginnt im Array, ein Tag weiter als der aktuelle (Welcher gelöscht werden soll)
+        console.log("Wettkampftag vorher: " + this.currentWettkampftagArray[i].wettkampfTag);
+        console.log("i = "+ i);
+        this.currentWettkampftagArray[i].wettkampfTag --;     //Wettkampftagnummer wird dekrementiert
 
-        await this.wettkampfDataProvider.update(this.selectedDTOs[i-1]);
+        console.log("Wettkampftag danach: " + this.currentWettkampftagArray[i].wettkampfTag);
+
+        if(this.currentWettkampftagArray[i].wettkampfTag==null) {
+          console.log("wettkampf doesnt exist");
+        }
+        else{
+          await this.wettkampfDataProvider.update(this.currentWettkampftagArray[i]);    //Wettkampftag mit aktualisierter Wettkampftagnummer speichern
+          this.currentWettkampftagArray[i - 1] = this.currentWettkampftagArray[i];      //Position im Array verschieben
+        }
       }
     }
     this.loadDistinctWettkampf();
+    return true;
   }
 
   //Creates Copy of current Wettkampftag


### PR DESCRIPTION
Bugfix: Wettkampftage wurden doppelt gespeichert (einmal beim hinzufügen und einmal beim abspeichern -> Zwei verschiedene Wettkampftage mit unterschiedlichen IDs). Wurde nun behoben, dadurch wurden auch andere Komplikationen gelöst 
Funktionaliät: Wenn ein Wettkampftag gelöscht wird, passt sich nun die Liste der Wettkampftage, so wie die Wettkampftagnummern der einzelnen Wettkampftage entpsrechend an. 