### PR TITLE
BSAPP-994

### DIFF
--- a/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
+++ b/bogenliga/src/app/modules/verwaltung/components/veranstaltung/veranstaltung-detail/wettkampftage/wettkampftage.component.html
@@ -111,7 +111,7 @@
           <input type="text"
                  class="form-control"
                  required
-                 pattern="(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z0-9\.\-\ ]{1,100}$"
+                 pattern="(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z0-9\.\-\/ ]{1,100}$"
                  id="wettkampftageStrasse"
                  name="wettkampftageStrasse"
                  #wettkampftageStrasse="ngModel"


### PR DESCRIPTION
Für "Veranstaltung - Details" (4.Bereich in der Aufzählung) im Eingabefeld "Straße und Hausnummer" ist es möglich ein "/" einzufügen.
Michael Stych: BSAPP-994