### PR TITLE
deleted 4 unused variables

### DIFF
--- a/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
+++ b/bogenliga/src/app/modules/sportjahresplan/components/schusszettel/schusszettel.component.ts
@@ -186,6 +186,7 @@ export class SchusszettelComponent implements OnInit {
     this.getAllPasse();
     this.getAllWettkaempfe();
     this.getAllVeranstaltungen();
+
   }
 
   /**

--- a/bogenliga/src/app/modules/wettkampf/mapper/wettkampf-ergebnis-mapper.ts
+++ b/bogenliga/src/app/modules/wettkampf/mapper/wettkampf-ergebnis-mapper.ts
@@ -16,9 +16,9 @@ export function toDO(ligatabelleErgebnisDTO: LigatabelleErgebnisDTO): Ligatabell
   ligatabelleErgebnisDO.mannschaft_id = ligatabelleErgebnisDTO.mannschaftId;
   ligatabelleErgebnisDO.mannschaft_name = ligatabelleErgebnisDTO.vereinName.toString() + '-' + ligatabelleErgebnisDTO.mannschaftNummer.toString();
   ligatabelleErgebnisDO.verein_id = ligatabelleErgebnisDTO.vereinId;
-  ligatabelleErgebnisDO.matchpunkte = ligatabelleErgebnisDTO.matchpkt.toString() + ' : ' + ligatabelleErgebnisDTO.matchpkt_gegen.toString();
-  ligatabelleErgebnisDO.satzpunkte = ligatabelleErgebnisDTO.satzpkt.toString() + ' : ' + ligatabelleErgebnisDTO.satzpkt_gegen.toString();
-  ligatabelleErgebnisDO.satzpkt_differenz = ligatabelleErgebnisDTO.satzpkt_differenz;
+  ligatabelleErgebnisDO.matchpunkte = ligatabelleErgebnisDTO.matchpkt.toString() + ' : ' + ligatabelleErgebnisDTO.matchpktGegen.toString();
+  ligatabelleErgebnisDO.satzpunkte = ligatabelleErgebnisDTO.satzpkt.toString() + ' : ' + ligatabelleErgebnisDTO.satzpktGegen.toString();
+  ligatabelleErgebnisDO.satzpkt_differenz = ligatabelleErgebnisDTO.satzpktDifferenz;
   ligatabelleErgebnisDO.tabellenplatz = ligatabelleErgebnisDTO.tabellenplatz;
   ligatabelleErgebnisDO.sortierung = ligatabelleErgebnisDTO.sortierung;
 

--- a/bogenliga/src/app/modules/wettkampf/types/datatransfer/wettkampf-ergebnis-dto.class.ts
+++ b/bogenliga/src/app/modules/wettkampf/types/datatransfer/wettkampf-ergebnis-dto.class.ts
@@ -14,10 +14,10 @@ export class LigatabelleErgebnisDTO implements DataTransferObject {
   vereinId: number;
   vereinName: string;
   matchpkt: number;
-  matchpkt_gegen: number;
+  matchpktGegen: number;
   satzpkt: number;
-  satzpkt_gegen: number;
-  satzpkt_differenz: number;
+  satzpktGegen: number;
+  satzpktDifferenz: number;
   sortierung: number;
   tabellenplatz: number;
 
@@ -33,10 +33,10 @@ export class LigatabelleErgebnisDTO implements DataTransferObject {
     vereinId?: number,
     vereinName?: string
     matchpkt?: number,
-    matchpkt_gegen?: number,
+    matchpktGegen?: number,
     satzpkt?: number,
-    satzpkt_gegen?: number,
-    satzpkt_differenz?: number,
+    satzpktGegen?: number,
+    satzpktDifferenz?: number,
     sortierung?: number,
     tabellenplatz?: number
   } = {}): LigatabelleErgebnisDTO {
@@ -57,10 +57,10 @@ export class LigatabelleErgebnisDTO implements DataTransferObject {
     copy.vereinId = optional.vereinId;
     copy.vereinName = optional.vereinName || '';
     copy.matchpkt = optional.matchpkt;
-    copy.matchpkt_gegen = optional.matchpkt_gegen;
+    copy.matchpktGegen = optional.matchpktGegen;
     copy.satzpkt = optional.satzpkt;
-    copy.satzpkt_gegen = optional.satzpkt_gegen;
-    copy.satzpkt_differenz = optional.satzpkt_differenz;
+    copy.satzpktGegen = optional.satzpktGegen;
+    copy.satzpktDifferenz = optional.satzpktDifferenz;
     copy.sortierung = optional.sortierung;
     copy.tabellenplatz = optional.tabellenplatz;
 


### PR DESCRIPTION
update: Refactored 3 variables which didn´t match backend with frontend
also a misspelled variable that didn´t match in the same file below

Changed variables to match Backend with Frontend:
matchpkt_gegen matchpktGegen
satzpkt_gegen  satzpktGegen
satzpkt_differenz  satzpktDifferenz

and one missspelled variable in the frontend 